### PR TITLE
Add CanonicalHostedZoneID NLB attribute as stack output

### DIFF
--- a/templates/darktrace-vsensor-main.template.yaml
+++ b/templates/darktrace-vsensor-main.template.yaml
@@ -787,6 +787,13 @@ Outputs:
       - VSensorStack
       - Outputs.LoadBalancerDNS
 
+  LoadBalancerDNSZoneNameID:
+    Description: Route 53 hosted zone name of the Network Load Balancer, required for osSensor clients.
+    Value:
+      Fn::GetAtt:
+      - VSensorStack
+      - Outputs.LoadBalancerDNSZoneNameID
+
   TrafficMirrorFilterId:
     Description: ID of the Traffic Mirror filter generated for Traffic Mirror sessions.
     Value:

--- a/templates/darktrace-vsensor-main.template.yaml
+++ b/templates/darktrace-vsensor-main.template.yaml
@@ -787,12 +787,12 @@ Outputs:
       - VSensorStack
       - Outputs.LoadBalancerDNS
 
-  LoadBalancerDNSZoneNameID:
+  LoadBalancerDNSZoneID:
     Description: Route 53 hosted zone name of the Network Load Balancer, required for osSensor clients.
     Value:
       Fn::GetAtt:
       - VSensorStack
-      - Outputs.LoadBalancerDNSZoneNameID
+      - Outputs.LoadBalancerDNSZoneID
 
   TrafficMirrorFilterId:
     Description: ID of the Traffic Mirror filter generated for Traffic Mirror sessions.

--- a/templates/darktrace-vsensor-workload.template.yaml
+++ b/templates/darktrace-vsensor-workload.template.yaml
@@ -1541,6 +1541,10 @@ Outputs:
     Description: DNS name of the Network Load Balancer, required for osSensor clients.
     Value: !GetAtt LoadBalancer.DNSName
 
+  LoadBalancerDNSZoneNameID:
+    Description: Route 53 hosted zone name of the Network Load Balancer, required for osSensor clients.
+    Value: !GetAtt LoadBalancer.CanonicalHostedZoneID
+
   TrafficMirrorFilterId:
     Description: ID of the Traffic Mirror filter generated for Traffic Mirror sessions.
     Value: !Ref TrafficMirrorFilter

--- a/templates/darktrace-vsensor-workload.template.yaml
+++ b/templates/darktrace-vsensor-workload.template.yaml
@@ -1541,7 +1541,7 @@ Outputs:
     Description: DNS name of the Network Load Balancer, required for osSensor clients.
     Value: !GetAtt LoadBalancer.DNSName
 
-  LoadBalancerDNSZoneNameID:
+  LoadBalancerDNSZoneID:
     Description: Route 53 hosted zone name of the Network Load Balancer, required for osSensor clients.
     Value: !GetAtt LoadBalancer.CanonicalHostedZoneID
 


### PR DESCRIPTION
Add CanonicalHostedZoneID NLB attribute as stack output
- This allows a parent stack to create a Route 53 alias record to point at the NLB
- Just outputting the DNS name is insufficient, as an ALIAS requires the hosted zone ID of the target when the target resource is not in the same hosted zone

Example:
```yaml
Resources:
  StackVSensor:
    Type: AWS::CloudFormation::Stack
    Properties:
      TemplateURL: !Ref VSensorDeploymentStackTemplateS3Uri
      Parameters:
        DarktraceInstanceHostname: !Ref SSMParamHostname
        DarktraceInstancePushtoken: !Ref SSMParamPpushtoken
        DarktraceInstanceProxy: !Ref SSMParamProxy
        InstanceType: !Ref VSensorInstanceType
        KeyPairName: !Ref EC2KPVSensorAppliance
        InstanceSecurityGroups: ''
        VsensorUpdatekey: !Ref SSMParamUpdatekey
        DesiredCapacityASG: !Ref VSensorDesiredCapacityASG
        MinSizeASG: !Ref VSensorMinSizeASG
        MaxSizeASG: !Ref VSensorMaxSizeASG
        osSensorHMAC: !Ref SSMParamHmac
        DeploymentVPC: !Ref VPCCore
        VpcCIDRBlock: !GetAtt VPCCore.CidrBlock
        SshCIDRBlock: !Ref SshCidrBlock
        Subnets: !Ref VSensorSubnets
        TrafficMirrorRuleNumber: 100
        TrafficMirrorSourceCIDR: 0.0.0.0/0
        TrafficMirrorDestCIDR: 0.0.0.0/0
        LogGroupRetention: 30
        LifecycleS3BucketDays: 7
        ShortID: ''
    DeletionPolicy: !Ref UpdateReplaceDeletePolicy
    UpdateReplacePolicy: !Ref UpdateReplaceDeletePolicy
  Route53RecordSetNLBVSensor:
    Type: AWS::Route53::RecordSet
    Properties:
      Name: !Sub ${AWS::Region}.example.net.
      Type: A
      AliasTarget:
        DNSName: !GetAtt StackVSensor.Outputs.LoadBalancerDNS
        EvaluateTargetHealth: false
        HostedZoneId: !GetAtt StackVSensor.Outputs.LoadBalancerDNSZoneID
    DeletionPolicy: !Ref UpdateReplaceDeletePolicy
    UpdateReplacePolicy: !Ref UpdateReplaceDeletePolicy
```